### PR TITLE
Fixes Class::MOP::load_class deprecation warnings

### DIFF
--- a/lib/Form/Toolkit/Field.pm
+++ b/lib/Form/Toolkit/Field.pm
@@ -1,4 +1,5 @@
 package Form::Toolkit::Field;
+use Class::Load;
 use Moose -traits => 'Form::Toolkit::Meta::Class::Trait::HasShortClass';
 use Moose::Util qw/apply_all_roles/;
 
@@ -191,7 +192,7 @@ sub add_role{
 
   ## This is better, as apply can be used to add new arguments
   ## See http://search.cpan.org/~ether/Moose-2.0801/lib/Moose/Role.pm#APPLYING_ROLES
-  Class::MOP::load_class( $role );
+  Class::Load::load_class( $role );
   $role->meta->apply($self, rebless_params => $new_args );
 
   ## Maintain important meta attributes.

--- a/lib/Form/Toolkit/Form.pm
+++ b/lib/Form/Toolkit/Form.pm
@@ -1,7 +1,7 @@
 package Form::Toolkit::Form;
 require 5.010_000;
 use Moose -traits => 'Form::Toolkit::Meta::Class::Trait::HasID';
-use Class::MOP;
+use Class::Load;
 
 use Form::Toolkit::Clerk::Hash;
 
@@ -158,7 +158,7 @@ sub add_field{
     }else{
       $f_class = 'Form::Toolkit::Field::'.$f_class;
     }
-    Class::MOP::load_class( $f_class );
+    Class::Load::load_class( $f_class );
     my $new_instance = $f_class->new({ form => $self , name => $name  });
     $ret =  $self->_add_field($new_instance);
   };

--- a/lib/Form/Toolkit/Test.pm
+++ b/lib/Form/Toolkit/Test.pm
@@ -1,6 +1,6 @@
 package Form::Toolkit::Test;
 use Moose;
-use Class::MOP;
+use Class::Load;
 use Module::Pluggable::Object;
 
 =head1 NAME
@@ -23,7 +23,7 @@ sub build_fields{
   my @res = ();
   my $mp = Module::Pluggable::Object->new( search_path => 'Form::Toolkit::Field' );
   foreach my $field_class ( $mp->plugins() ){
-    Class::MOP::load_class($field_class);
+    Class::Load::load_class($field_class);
     $self->add_field('+'.$field_class , 'field_'.$field_class->meta->short_class() );
   }
 


### PR DESCRIPTION
Hey,

This fixes the warnings produced by the deprecation of Class::MOP::load_class. Below is a blurb the Moose guys have been distributing.

---

We recently deprecated Class::MOP::load_class in Moose. It appears that your module is affected. You can read more about the change here: https://metacpan.org/pod/release/ETHER/Moose-2.1106-TRIAL/lib/Moose/Manual/Delta.pod#pod2.1200 We recommend that you take a look at your code to see if it indeed does need to be updated with respect to the latest Moose release, 2.1106-TRIAL. If you have any questions, then please ask either on Moose mailing list : http://lists.perl.org/list/moose.html or on #moose & #moose-dev on irc.perl.org.
